### PR TITLE
fix: Configure Dependabot schedule with Copenhagen timezone

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,29 @@
 version: 2
 
 updates:
+  # Scan for Python pip dependencies
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "21:12"
+      timezone: "Europe/Copenhagen"
+
   # Scan for Docker updates in Dockerfile
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "21:12"
+      timezone: "Europe/Copenhagen"
 
   # Include GitHub Actions workflows
   - package-ecosystem: "github-actions"
     directory: "/.github/workflows"
     schedule:
       interval: "weekly"
+      day: "monday"
+      time: "21:12"
+      timezone: "Europe/Copenhagen"


### PR DESCRIPTION
## Summary
- Set Dependabot to run every Monday at 21:12 Copenhagen time (Europe/Copenhagen timezone)
- Added pip ecosystem for Python dependency updates
- Applied consistent scheduling across all package ecosystems

## Changes
- Updated `.github/dependabot.yml` with proper `day`, `time`, and `timezone` settings
- Added Python pip dependency scanning (was missing)
- All ecosystems (pip, docker, github-actions) now run at the same time

## Benefits
- Timezone-aware scheduling handles daylight saving time automatically
- Dependabot will always run at 21:12 local Copenhagen time, year-round
- Centralized dependency updates on Monday evenings
- Python dependencies are now tracked alongside Docker and GitHub Actions

## Testing
- Configuration validated against Dependabot YAML schema
- Branch created from main with isolated changes