### PR TITLE
fix: Reset patch version to 1 at the beginning of each month

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -107,6 +107,8 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -129,10 +131,13 @@ jobs:
       - name: Generate semantic version tag
         id: version
         run: |
-          # Semantic versioning: YY.M.PATCH
+          # Semantic versioning: YY.M.PATCH (patch resets to 1 each month)
           YEAR=$(date +'%y')
           MONTH=$(date +'%-m')
-          PATCH=${{ github.run_number }}
+
+          # Count existing tags for current month and increment
+          EXISTING_TAGS=$(git tag -l "${YEAR}.${MONTH}.*" | wc -l)
+          PATCH=$((EXISTING_TAGS + 1))
 
           VERSION="${YEAR}.${MONTH}.${PATCH}"
 
@@ -142,7 +147,7 @@ jobs:
             echo "month=${MONTH}"
           } >> "$GITHUB_OUTPUT"
 
-          echo "Generated version: ${VERSION}"
+          echo "Generated version: ${VERSION} (${EXISTING_TAGS} existing tags for ${YEAR}.${MONTH})"
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
Fixes the version tagging strategy to reset the patch number to 1 at the beginning of each month, following the pattern YY.M.PATCH where PATCH resets monthly.

## Problem
The current implementation uses `github.run_number` which is a global counter that never resets. This means:
- January build 31: `26.1.31`
- February build 32: `26.2.32` ❌ (should be `26.2.1`)

## Solution
Changed to count existing git tags for the current month:
```bash
EXISTING_TAGS=$(git tag -l "${YEAR}.${MONTH}.*" | wc -l)
PATCH=$((EXISTING_TAGS + 1))
```

## Changes
- Updated version generation to count existing tags matching `YY.M.*` pattern
- Added `fetch-depth: 0` to checkout step to fetch all tags
- Patch number now automatically resets to 1 when the month changes

## Example
- **January builds:** 26.1.1, 26.1.2, 26.1.3, ..., 26.1.31
- **February 1st build:** 26.2.1 ✅ (resets to 1)
- **February subsequent builds:** 26.2.2, 26.2.3, etc.

## Testing
- Validated with actionlint (no errors)
- Logic tested: counts tags, increments, automatically resets when no tags found for new month