### PR TITLE
fix: Upload Bandit security reports to GitHub Security tab

### DIFF
--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -114,6 +114,9 @@ jobs:
   security-audit:
     name: 🛡️ Security Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -133,6 +136,19 @@ jobs:
           bandit -r app.py -f txt -o bandit-weekly-report.txt || true
         continue-on-error: true
 
+      - name: Convert Bandit JSON to SARIF
+        run: |
+          pip install bandit-sarif-formatter
+          bandit -r app.py -f sarif -o bandit-weekly-report.sarif || true
+        continue-on-error: true
+
+      - name: Upload Bandit SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: bandit-weekly-report.sarif
+          category: bandit-weekly
+
       - name: Upload Bandit reports
         uses: actions/upload-artifact@v6
         with:
@@ -140,6 +156,7 @@ jobs:
           path: |
             bandit-weekly-report.json
             bandit-weekly-report.txt
+            bandit-weekly-report.sarif
           retention-days: 30
 
       - name: Security scan summary
@@ -149,9 +166,10 @@ jobs:
             echo ""
             echo "✅ Security scans completed"
             echo ""
-            echo "**Reports uploaded as artifacts**"
-            echo "- Bandit JSON report"
-            echo "- Bandit text report"
+            echo "**Reports uploaded:**"
+            echo "- Bandit JSON report (artifact)"
+            echo "- Bandit text report (artifact)"
+            echo "- Bandit SARIF report (GitHub Security tab)"
           } >> "$GITHUB_STEP_SUMMARY"
 
   maintenance-summary:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,6 +42,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.backend_changed == 'true'
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@v4
 
@@ -89,6 +92,19 @@ jobs:
           bandit -r app.py -f txt -o bandit-report.txt || true
         continue-on-error: true
 
+      - name: Convert Bandit JSON to SARIF
+        run: |
+          pip install bandit-sarif-formatter
+          bandit -r app.py -f sarif -o bandit-report.sarif || true
+        continue-on-error: true
+
+      - name: Upload Bandit SARIF to GitHub Security
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: bandit-report.sarif
+          category: bandit
+
       - name: Upload Bandit report
         uses: actions/upload-artifact@v6
         with:
@@ -96,6 +112,7 @@ jobs:
           path: |
             bandit-report.json
             bandit-report.txt
+            bandit-report.sarif
           retention-days: 90
 
   production-build:


### PR DESCRIPTION
## Summary
Fixes Bandit security scan reports not uploading to GitHub's Security platform. Reports are now uploaded in SARIF format to the Security tab for better visibility and tracking.

## Problem
Currently, Bandit security scans run successfully but reports are only uploaded as workflow artifacts. They are not visible in the GitHub Security tab where security alerts should be centralized.

**Current state:**
- Bandit runs and generates JSON/TXT reports
- Reports stored as artifacts only
- No integration with GitHub Security platform
- Security findings not tracked in Security > Code scanning alerts

## Solution
- Generate SARIF format output from Bandit using `bandit-sarif-formatter`
- Upload SARIF reports to GitHub Security tab using `github/codeql-action/upload-sarif`
- Add `security-events: write` permissions to relevant jobs
- Apply to both `docker-publish` (on main merge) and `dependabot-weekly` workflows

## Changes Made

### docker-publish.yml
1. Added `security-events: write` permission to `test-and-validation` job
2. Added step to install `bandit-sarif-formatter` and generate SARIF output
3. Added `github/codeql-action/upload-sarif` step with category `bandit`
4. Updated artifact uploads to include SARIF file

### dependabot-weekly.yml
1. Added `security-events: write` permission to `security-audit` job
2. Added SARIF generation step
3. Added upload to GitHub Security with category `bandit-weekly`
4. Updated summary to reflect SARIF upload

## Benefits
- ✅ Security findings visible in GitHub Security tab
- ✅ Centralized security alerts alongside CodeQL results
- ✅ Better tracking and management of security issues
- ✅ Integration with GitHub's security tooling
- ✅ Historical artifact uploads preserved for manual review

## Testing
- Validated with actionlint (all workflows pass)
- SARIF format supported by GitHub Security
- Permissions correctly configured for security-events writing

## Result
After merge, Bandit security scan results will appear in:
- **Security > Code scanning alerts** (new!)
- Workflow artifacts (existing)