### PR TITLE
chore(deps): consolidate weekly Dependabot updates

### DIFF
--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -15,7 +15,7 @@ jobs:
     name: 📦 Dependency Status Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Check for open Dependabot PRs
         id: dependabot_prs
@@ -118,7 +118,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -150,7 +150,7 @@ jobs:
           category: bandit-weekly
 
       - name: Upload Bandit reports
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-weekly-security-report-${{ github.run_number }}
           path: |

--- a/.github/workflows/dependabot-weekly.yml
+++ b/.github/workflows/dependabot-weekly.yml
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Bandit SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: bandit-weekly-report.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -139,7 +139,7 @@ jobs:
           echo "DOCKER_PASSWORD is set: $([ -z "${{ secrets.DOCKER_PASSWORD }}" ] && echo 'NO' || echo 'YES')"
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -167,7 +167,7 @@ jobs:
           echo "Generated version: ${VERSION} (${EXISTING_TAGS} existing tags for ${YEAR}.${MONTH})"
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -99,7 +99,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Bandit SARIF to GitHub Security
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: bandit-report.sarif

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -106,7 +106,7 @@ jobs:
           category: bandit
 
       - name: Upload Bandit report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-security-report-${{ github.run_number }}
           path: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
     outputs:
       backend_changed: ${{ steps.filter.outputs.backend }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -46,7 +46,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -123,7 +123,7 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -205,7 +205,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -272,7 +272,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -133,7 +133,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload Bandit report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: bandit-security-report
           path: |
@@ -142,7 +142,7 @@ jobs:
           retention-days: 90
 
       - name: Upload test coverage report
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-report
           path: |

--- a/.github/workflows/pr-quality-gate.yml
+++ b/.github/workflows/pr-quality-gate.yml
@@ -19,7 +19,7 @@ jobs:
       backend_changed: ${{ steps.filter.outputs.backend }}
       workflows_changed: ${{ steps.filter.outputs.workflows }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -66,7 +66,7 @@ jobs:
     needs: discover-changes
     if: needs.discover-changes.outputs.backend_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -89,7 +89,7 @@ jobs:
     needs: discover-changes
     if: needs.discover-changes.outputs.workflows_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run actionlint
         uses: raven-actions/actionlint@v2
@@ -102,7 +102,7 @@ jobs:
     needs: discover-changes
     if: needs.discover-changes.outputs.backend_changed == 'true'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -160,7 +160,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
@@ -180,7 +180,7 @@ jobs:
       needs.lint-backend.result == 'success' &&
       needs.quality-backend.result == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Build Docker image
         run: |

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 flask==3.1.2
 werkzeug==3.1.5
 markupsafe==3.0.3
-wheel==0.46.2
+wheel==0.46.3
 
 # Security
 flask-talisman==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,7 +14,7 @@ pytest-cov==7.0.0
 pytest-asyncio==1.3.0
 
 # Code Quality
-pylint==4.0.4
+pylint==4.0.5
 
 # Security Scanning
 bandit==1.9.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Core Framework
-flask==3.1.2
-werkzeug==3.1.5
+flask==3.1.3
+werkzeug==3.1.6
 markupsafe==3.0.3
 wheel==0.46.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ wheel==0.46.2
 
 # Security
 flask-talisman==1.1.0
-flask-limiter==3.5.0
+flask-limiter==4.1.1
 
 # Testing
 pytest==9.0.2


### PR DESCRIPTION
## Summary

Consolidates 11 open Dependabot PRs into a single PR. All checks were green individually; this just bundles them so reviews/merges happen once instead of eleven times.

## Bumps Included

### Python dependencies (`requirements.txt`)
| Package | From | To | Notes |
|---|---|---|---|
| flask | 3.1.2 | 3.1.3 | Security fix (GHSA-68rp-wp8r-4726) |
| werkzeug | 3.1.5 | 3.1.6 | Security fix (GHSA-29vq-49wr-vm6x) |
| flask-limiter | 3.5.0 | 4.1.1 | Major version — internal modules renamed but our imports (`flask_limiter.Limiter`, `flask_limiter.util.get_remote_address`) remain on the public API |
| pylint | 4.0.4 | 4.0.5 | Patch |
| wheel | 0.46.2 | 0.46.3 | Patch |

### GitHub Actions workflows
| Action | From | To |
|---|---|---|
| actions/checkout | 4 | 6 |
| actions/upload-artifact | 6 | 7 |
| github/codeql-action | 3 | 4 |
| docker/build-push-action | 6 | 7 |
| docker/login-action | 3 | 4 |

## Supersedes

- #44 (flask-limiter)
- #45 (actions/checkout)
- #46 (wheel)
- #47 (codeql-action)
- #48 (werkzeug — already covered by group bump #51)
- #49 (pylint)
- #50 (flask — already covered by group bump #51)
- #51 (pip group: flask + werkzeug)
- #52 (upload-artifact)
- #53 (docker/build-push-action)
- #54 (docker/login-action)

## Test plan

Verified locally before pushing:

- [x] `pylint app.py` → 10.00/10
- [x] `pytest tests/ --cov=.` → 35 passed, 97% coverage
- [x] `black --check` → clean
- [x] `bandit -r app.py` → 0 issues
- [x] `actionlint .github/workflows/*.yml` → clean

CI will re-run all of the above on this PR.