### PR TITLE
chore(deps): bundle Dependabot sweep + add grouping config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,16 @@ updates:
       day: "monday"
       time: "21:12"
       timezone: "Europe/Copenhagen"
+    groups:
+      # Bundle patch + minor bumps into a single weekly PR per category.
+      # Security advisories always come as separate PRs (Dependabot default).
+      # Majors stay separate so they get a proper review.
+      pip-production:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      pip-development:
+        dependency-type: "development"
+        update-types: ["minor", "patch"]
 
   # Scan for Docker updates in Dockerfile
   - package-ecosystem: "docker"
@@ -18,6 +28,10 @@ updates:
       day: "monday"
       time: "21:12"
       timezone: "Europe/Copenhagen"
+    groups:
+      docker:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Include GitHub Actions workflows
   - package-ecosystem: "github-actions"
@@ -27,3 +41,7 @@ updates:
       day: "monday"
       time: "21:12"
       timezone: "Europe/Copenhagen"
+    groups:
+      github-actions:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 # Core Framework
 flask==3.1.3
-werkzeug==3.1.6
+werkzeug==3.1.8
 markupsafe==3.0.3
-wheel==0.46.3
+wheel==0.47.0
 
 # Security
 flask-talisman==1.1.0
@@ -10,13 +10,13 @@ flask-limiter==4.1.1
 
 # Testing
 pytest==9.0.3
-pytest-cov==7.0.0
+pytest-cov==7.1.0
 pytest-asyncio==1.3.0
 
 # Code Quality
 pylint==4.0.5
 
 # Security Scanning
-bandit==1.9.3
+bandit==1.9.4
 # Note: safety temporarily disabled - pydantic dependency not compatible with Python 3.14
 # Will re-enable once compatibility is resolved


### PR DESCRIPTION
## Why

Eight Dependabot PRs were queued. This PR bundles the safe patch + minor pip bumps and adds `groups:` to `.github/dependabot.yml`. The four GitHub Actions **major** bumps (#57, #58, #59, #60) are left as individual PRs so they get proper review.

## Bundled bumps (supersedes #61, #62, #63, #64)

| Package | From | To | Type |
|---|---|---|---|
| werkzeug | 3.1.6 | 3.1.8 | patch |
| wheel | 0.46.3 | 0.47.0 | minor |
| pytest-cov | 7.0.0 | 7.1.0 | minor |
| bandit | 1.9.3 | 1.9.4 | patch |

## Left for separate review (majors)

- #57 actions/github-script v8 → v9
- #58 docker/setup-qemu-action v3 → v4
- #59 codecov/codecov-action v5 → v6
- #60 docker/setup-buildx-action v3 → v4

## Verification

- `pip install -r requirements.txt` — clean
- `pytest --no-cov` — **35/35 passed**

## 🧱 Dependabot grouping

Future weekly runs produce: 1 PR for pip prod (minor+patch), 1 for pip dev, 1 for docker (minor+patch), 1 for github-actions (minor+patch). Majors and security advisories stay individual.

## Closes

Supersedes #61, #62, #63, #64
