### PR TITLE
chore(deps): weekly security digest #72 — bump pytest & pylint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,12 +9,12 @@ flask-talisman==1.1.0
 flask-limiter==4.1.1
 
 # Testing
-pytest==9.0.3
+pytest==9.1.1
 pytest-cov==7.1.0
 pytest-asyncio==1.4.0
 
 # Code Quality
-pylint==4.0.5
+pylint==4.0.6
 # Note: astroid is a transitive dependency of pylint (not directly pinned here).
 # Latest astroid (4.1.2) is resolved automatically when pylint is installed.
 


### PR DESCRIPTION
Closes #72

Weekly security digest follow-up. No vulnerabilities; outdated sweep only.

## Updates
- pytest: 9.0.3 → 9.1.1
- pylint: 4.0.5 → 4.0.6

## Skipped
- astroid 4.0.4 → 4.1.2 (transitive via pylint; resolved automatically)